### PR TITLE
Fix volatile operator= in Real2.

### DIFF
--- a/cedr/cedr_caas.cpp
+++ b/cedr/cedr_caas.cpp
@@ -336,3 +336,6 @@ template class cedr::caas::CAAS<Kokkos::OpenMP>;
 #ifdef KOKKOS_ENABLE_CUDA
 template class cedr::caas::CAAS<Kokkos::Cuda>;
 #endif
+#ifdef KOKKOS_ENABLE_THREADS
+template class cedr::caas::CAAS<Kokkos::Threads>;
+#endif

--- a/cedr/cedr_caas.cpp
+++ b/cedr/cedr_caas.cpp
@@ -9,6 +9,16 @@ namespace Kokkos {
 struct Real2 {
   cedr::Real v[2];
   KOKKOS_INLINE_FUNCTION Real2 () { v[0] = v[1] = 0; }
+
+  KOKKOS_INLINE_FUNCTION void operator= (const Real2& s) {
+    v[0] = s.v[0];
+    v[1] = s.v[1];
+  }
+  KOKKOS_INLINE_FUNCTION void operator= (const volatile Real2& s) volatile {
+    v[0] = s.v[0];
+    v[1] = s.v[1];
+  }
+
   KOKKOS_INLINE_FUNCTION Real2& operator+= (const Real2& o) {
     v[0] += o.v[0];
     v[1] += o.v[1];

--- a/cedr/cedr_cdr.hpp
+++ b/cedr/cedr_cdr.hpp
@@ -8,6 +8,11 @@
 
 namespace cedr {
 // Constrained Density Reconstructor interface.
+//   Find a point Qm in the set
+//      { Qm: ( i) e'Qm = Qm_global
+//            (ii) Qm_min <= Qm <= Qm_max },
+// where e is the vector of 1s. Each algorithm in CEDR has its own optimality
+// principle to decide on the point.
 struct CDR {
   typedef std::shared_ptr<CDR> Ptr;
 

--- a/cedr/cedr_qlt.cpp
+++ b/cedr/cedr_qlt.cpp
@@ -1258,3 +1258,6 @@ template class cedr::qlt::QLT<Kokkos::OpenMP>;
 #ifdef KOKKOS_ENABLE_CUDA
 template class cedr::qlt::QLT<Kokkos::Cuda>;
 #endif
+#ifdef KOKKOS_ENABLE_THREADS
+template class cedr::qlt::QLT<Kokkos::Threads>;
+#endif


### PR DESCRIPTION
@kuberry reported a compilation error on Mac with LLVM 10.0.0. It looks quite sensible and is probably just being missed by other compilers. This PR will fix that error. Thanks @kuberry!