### PR TITLE
Support user provided memory

### DIFF
--- a/cedr/cedr.hpp
+++ b/cedr/cedr.hpp
@@ -24,7 +24,7 @@ typedef double Real;
 // One can solve a subset of these.
 //   If !conserve, then the CDR does not alter the tracer mass, but it does not
 // correct for any failure in mass conservation in the field given to it.
-//   If consistent but !shapepreserve, the the CDR solves the dynamic range
+//   If consistent but !shapepreserve, then the CDR solves the dynamic range
 // preservation problem rather than the local bound preservation problem.
 struct ProblemType {
   enum : Int {

--- a/cedr/cedr_caas.hpp
+++ b/cedr/cedr_caas.hpp
@@ -16,6 +16,7 @@ public:
   typedef typename cedr::impl::DeviceType<ExeSpace>::type Device;
   typedef CAAS<ExeSpace> Me;
   typedef std::shared_ptr<Me> Ptr;
+  typedef Kokkos::View<Real*, Kokkos::LayoutLeft, Device> RealList;
 
 public:
   struct UserAllReducer {
@@ -39,6 +40,12 @@ public:
 
   void end_tracer_declarations() override;
 
+  void get_buffers_sizes(size_t& buf1, size_t& buf2) override;
+
+  void set_buffers(Real* buf1, Real* buf2) override;
+
+  void finish_setup() override;
+
   int get_problem_type(const Int& tracer_idx) const override;
 
   Int get_num_tracers() const override;
@@ -58,7 +65,6 @@ public:
   Real get_Qm(const Int& lclcellidx, const Int& tracer_idx) const override;
 
 protected:
-  typedef Kokkos::View<Real*, Kokkos::LayoutLeft, Device> RealList;
   typedef cedr::impl::Unmanaged<RealList> UnmanagedRealList;
   typedef Kokkos::View<Int*, Kokkos::LayoutLeft, Device> IntList;
 
@@ -78,12 +84,16 @@ protected:
   IntList probs_, t2r_;
   typename IntList::HostMirror probs_h_;
   RealList d_, send_, recv_;
+  bool finished_setup_;
 
   void reduce_globally();
 
 PRIVATE_CUDA:
   void reduce_locally();
   void finish_locally();
+
+private:
+  void get_buffers_sizes(size_t& buf1, size_t& buf2, size_t& buf3);
 };
 
 namespace test {

--- a/cedr/cedr_cdr.hpp
+++ b/cedr/cedr_cdr.hpp
@@ -16,7 +16,25 @@ namespace cedr {
 struct CDR {
   typedef std::shared_ptr<CDR> Ptr;
 
+  struct Options {
+    // In exact arithmetic, mass is conserved exactly and bounds of a feasible
+    // problem are not violated. In inexact arithmetic, these properties are
+    // inexact, and approximation quality of one can be preferred to that of the
+    // other. Use this option to prefer numerical mass conservation over
+    // numerical bounds nonviolation. In practice, this option governs errrs at
+    // the level of 10 to 1000 times numeric_limits<Real>::epsilon().
+    bool prefer_numerical_mass_conservation_to_numerical_bounds;
+
+    Options ()
+      : prefer_numerical_mass_conservation_to_numerical_bounds(false)
+    {}
+  };
+
+  CDR (const Options options = Options()) : options_(options) {}
+
   virtual void print(std::ostream& os) const {}
+
+  const Options& get_options () const { return options_; }
 
   // Set up QLT tracer metadata. Call declare_tracer in order of the tracer
   // index in the caller's numbering. Once end_tracer_declarations is called, it
@@ -82,6 +100,9 @@ struct CDR {
   // Get a cell's tracer mass Qm after the QLT algorithm has run.
   KOKKOS_FUNCTION
   virtual Real get_Qm(const Int& lclcellidx, const Int& tracer_idx) const = 0;
+
+protected:
+  Options options_;
 };
 } // namespace cedr
 

--- a/cedr/cedr_cdr.hpp
+++ b/cedr/cedr_cdr.hpp
@@ -29,6 +29,17 @@ struct CDR {
   // It is an error to call this function from a parallel region.
   virtual void end_tracer_declarations() = 0;
 
+  // Optionally query the sizes of the two primary memory buffers. This
+  // operation is valid after end_tracer_declarations was called.
+  virtual void get_buffers_sizes(size_t& buf1, size_t& buf2) = 0;
+  // Optionally provide the two primary memory buffers. These pointers must
+  // point to memory having at least the sizes returned by get_buffer_sizes.
+  virtual void set_buffers(Real* buf1, Real* buf2) = 0;
+
+  // Call this method to finish the setup phase. The subsequent methods are
+  // valid only after this method has been called.
+  virtual void finish_setup() = 0;
+
   virtual int get_problem_type(const Int& tracer_idx) const = 0;
 
   virtual Int get_num_tracers() const = 0;

--- a/cedr/cedr_local.cpp
+++ b/cedr/cedr_local.cpp
@@ -252,7 +252,7 @@ Int test_1eq_nonneg () {
       solve_1eq_bc_qp(n, w, a, b, xlo, xhi, y, x_ls);
       const Real rd_caas = reldif(x_caas, x1_caas, 2);
       const Real rd_ls = reldif(x_ls, x1_ls, 2);
-      if (rd_ls > 1e1*std::numeric_limits<Real>::epsilon() ||
+      if (rd_ls > 5e1*std::numeric_limits<Real>::epsilon() ||
           rd_caas > 1e1*std::numeric_limits<Real>::epsilon()) {
         pr(puf(rd_ls) pu(rd_caas));
         if (verbose) {

--- a/cedr/cedr_local.hpp
+++ b/cedr/cedr_local.hpp
@@ -29,7 +29,13 @@ KOKKOS_INLINE_FUNCTION
 Int solve_1eq_bc_qp_2d(const Real* w, const Real* a, const Real b,
                        const Real* xlo, const Real* xhi,
                        const Real* y, Real* x,
-                       const bool clip = true);
+                       const bool clip = true,
+                       // The 2D algorithm doesn't need to terminate based on a
+                       // tolerance, but by default it will exit early if the ND
+                       // algorithm would. Set this to false to run the full 2D
+                       // algorithm w/o checking the tolerance at start. If this
+                       // is false, the feasibility check is also disabled.
+                       const bool early_exit_on_tol = true);
 
 // ClipAndAssuredSum. Minimize the 1-norm with w = 1s. Does not check for
 // feasibility.

--- a/cedr/cedr_local_inl.hpp
+++ b/cedr/cedr_local_inl.hpp
@@ -69,10 +69,13 @@ KOKKOS_INLINE_FUNCTION
 Int solve_1eq_bc_qp_2d (const Real* w, const Real* a, const Real b,
                         const Real* xlo, const Real* xhi, 
                         const Real* y, Real* x,
-                        const bool clip) {
-  const Real r_tol = impl::calc_r_tol(b, a, y, 2);
-  Int info = impl::check_lu(2, a, b, xlo, xhi, r_tol, x);
-  if (info == -1) return info;
+                        const bool clip, const bool early_exit_on_tol) {
+  Int info;
+  if (early_exit_on_tol) {
+    const Real r_tol = impl::calc_r_tol(b, a, y, 2);
+    Int info = impl::check_lu(2, a, b, xlo, xhi, r_tol, x);
+    if (info == -1) return info;
+  }
 
   { // Check if the optimal point ignoring bound constraints is in bounds.
     Real qmass = 0, dm = b;

--- a/cedr/cedr_qlt.cpp
+++ b/cedr/cedr_qlt.cpp
@@ -113,7 +113,7 @@ Int init_tree (const Int& my_rank, const tree::Node::Ptr& node, Int& id) {
     depth = std::max(depth, init_tree(my_rank, node->kids[i], id));
   }
   if (node->nkids) {
-    node->rank = node->kids[0]->rank;
+    if (node->rank < 0) node->rank = node->kids[0]->rank;
     node->cellidx = id++;
   } else {
     cedr_throw_if(node->rank == my_rank && (node->cellidx < 0 || node->cellidx >= id),
@@ -516,11 +516,22 @@ void QLT<ES>::MetaData::init (const MetaDataBuilder& mdb) {
 }
 
 template <typename ES>
-void QLT<ES>::BulkData::init (const MetaData& md, const Int& nslots) {
-  l2r_data_ = RealList("QLT l2r_data", md.a_h.prob2bl2r[md.nprobtypes]*nslots);
-  r2l_data_ = RealList("QLT r2l_data", md.a_h.prob2br2l[md.nprobtypes]*nslots);
+void QLT<ES>::BulkData::init (const size_t& l2r_sz, const size_t& r2l_sz) {
+  l2r_data_ = RealList("QLT l2r_data", l2r_sz);
+  r2l_data_ = RealList("QLT r2l_data", r2l_sz);
   l2r_data = l2r_data_;
   r2l_data = r2l_data_;
+  inited_ = true;
+}
+
+template <typename ES>
+void QLT<ES>::BulkData::init (Real* buf1, const size_t& l2r_sz,
+                              Real* buf2, const size_t& r2l_sz) {
+  l2r_data_ = RealList(buf1, l2r_sz);
+  r2l_data_ = RealList(buf2, r2l_sz);
+  l2r_data = l2r_data_;
+  r2l_data = r2l_data_;
+  inited_ = true;
 }
 
 template <typename ES>
@@ -633,7 +644,28 @@ template <typename ES>
 void QLT<ES>::end_tracer_declarations () {
   md_.init(*mdb_);
   mdb_ = nullptr;
-  bd_.init(md_, ns_->nslots);
+}
+
+template <typename ES>
+void QLT<ES>::get_buffers_sizes (size_t& buf1, size_t& buf2) {
+  const auto nslots = ns_->nslots;
+  buf1 = md_.a_h.prob2bl2r[md_.nprobtypes]*nslots;
+  buf2 = md_.a_h.prob2br2l[md_.nprobtypes]*nslots;
+}
+
+template <typename ES>
+void QLT<ES>::set_buffers (Real* buf1, Real* buf2) {
+  size_t l2r_sz, r2l_sz;
+  get_buffers_sizes(l2r_sz, r2l_sz);
+  bd_.init(buf1, l2r_sz, buf2, r2l_sz);
+}
+
+template <typename ES>
+void QLT<ES>::finish_setup () {
+  if (bd_.inited()) return;
+  size_t l2r_sz, r2l_sz;
+  get_buffers_sizes(l2r_sz, r2l_sz);
+  bd_.init(l2r_sz, r2l_sz);
 }
 
 template <typename ES>
@@ -933,6 +965,7 @@ template <typename ES> void QLT<ES>
 
 template <typename ES>
 void QLT<ES>::run () {
+  cedr_assert(bd_.inited());
   Timer::start(Timer::qltrunl2r);
   // Number of data per slot.
   const Int l2rndps = md_.a_h.prob2bl2r[md_.nprobtypes];
@@ -962,9 +995,9 @@ public:
   typedef QLT<Kokkos::DefaultExecutionSpace> QLTT;
 
   TestQLT (const Parallel::Ptr& p, const tree::Node::Ptr& tree,
-           const Int& ncells, const bool verbose=false)
+           const Int& ncells, const bool external_memory, const bool verbose)
     : TestRandomized("QLT", p, ncells, verbose),
-      qlt_(p, ncells, tree), tree_(tree)
+      qlt_(p, ncells, tree), tree_(tree), external_memory_(external_memory)
   {
     if (verbose) qlt_.print(std::cout);
     init();
@@ -973,6 +1006,8 @@ public:
 private:
   QLTT qlt_;
   tree::Node::Ptr tree_;
+  bool external_memory_;
+  typename QLTT::RealList buf1_, buf2_;
 
   CDR& get_cdr () override { return qlt_; }
 
@@ -1007,6 +1042,14 @@ private:
     for (const auto& t : tracers_)
       qlt_.declare_tracer(t.problem_type, 0);
     qlt_.end_tracer_declarations();
+    if (external_memory_) {
+      size_t l2r_sz, r2l_sz;
+      qlt_.get_buffers_sizes(l2r_sz, r2l_sz);
+      buf1_ = typename QLTT::RealList("buf1", l2r_sz);
+      buf2_ = typename QLTT::RealList("buf2", r2l_sz);
+      qlt_.set_buffers(buf1_.data(), buf2_.data());
+    }
+    qlt_.finish_setup();
     cedr_assert(qlt_.get_num_tracers() == static_cast<Int>(tracers_.size()));
     for (size_t i = 0; i < tracers_.size(); ++i) {
       const auto pt = qlt_.get_problem_type(i);
@@ -1036,8 +1079,9 @@ private:
 // Test all QLT variations and situations.
 Int test_qlt (const Parallel::Ptr& p, const tree::Node::Ptr& tree,
               const Int& ncells, const Int nrepeat,
-              const bool write, const bool verbose) {
-  return TestQLT(p, tree, ncells, verbose).run<TestQLT::QLTT>(nrepeat, write);
+              const bool write, const bool external_memory, const bool verbose) {
+  return TestQLT(p, tree, ncells, external_memory, verbose)
+    .run<TestQLT::QLTT>(nrepeat, write);
 }
 } // namespace test
 
@@ -1194,19 +1238,22 @@ Int unittest_QLT (const Parallel::Ptr& p, const bool write_requested=false) {
   const Mesh::ParallelDecomp::Enum dists[] = { Mesh::ParallelDecomp::contiguous,
                                                Mesh::ParallelDecomp::pseudorandom };
   Int nerr = 0;
-  for (size_t is = 0, islim = sizeof(szs)/sizeof(*szs); is < islim; ++is)
-    for (size_t id = 0, idlim = sizeof(dists)/sizeof(*dists); id < idlim; ++id)
-    for (bool imbalanced: {false, true}) {
-      if (p->amroot()) {
-        std::cout << " (" << szs[is] << ", " << id << ", " << imbalanced << ")";
-        std::cout.flush();
+  for (size_t is = 0, islim = sizeof(szs)/sizeof(*szs); is < islim; ++is) {
+    for (size_t id = 0, idlim = sizeof(dists)/sizeof(*dists); id < idlim; ++id) {
+      for (bool imbalanced: {false, true}) {
+        const auto external_memory = imbalanced;
+        if (p->amroot()) {
+          std::cout << " (" << szs[is] << ", " << id << ", " << imbalanced << ")";
+          std::cout.flush();
+        }
+        Mesh m(szs[is], p, dists[id]);
+        tree::Node::Ptr tree = make_tree(m, imbalanced);
+        const bool write = (write_requested && m.ncell() < 3000 &&
+                            is == islim-1 && id == idlim-1);
+        nerr += test::test_qlt(p, tree, m.ncell(), 1, write, external_memory, false);
       }
-      Mesh m(szs[is], p, dists[id]);
-      tree::Node::Ptr tree = make_tree(m, imbalanced);
-      const bool write = (write_requested && m.ncell() < 3000 &&
-                          is == islim-1 && id == idlim-1);
-      nerr += test::test_qlt(p, tree, m.ncell(), 1, write);
     }
+  }
   return nerr;
 }
 
@@ -1238,7 +1285,7 @@ Int run_unit_and_randomized_tests (const Parallel::Ptr& p, const Input& in) {
     Timer::start(Timer::total); Timer::start(Timer::tree);
     tree::Node::Ptr tree = make_tree(m, false);
     Timer::stop(Timer::tree);
-    test::test_qlt(p, tree, in.ncells, in.nrepeat, false, in.verbose);
+    test::test_qlt(p, tree, in.ncells, in.nrepeat, false, false, in.verbose);
     Timer::stop(Timer::total);
     if (p->amroot()) Timer::print();
   }

--- a/cedr/cedr_qlt.hpp
+++ b/cedr/cedr_qlt.hpp
@@ -146,6 +146,7 @@ public:
   typedef typename cedr::impl::DeviceType<ExeSpace>::type Device;
   typedef QLT<ExeSpace> Me;
   typedef std::shared_ptr<Me> Ptr;
+  typedef Kokkos::View<Real*, Device> RealList;
   
   // Set up QLT topology and communication data structures based on a tree. Both
   // ncells and tree refer to the global mesh, not just this processor's
@@ -171,6 +172,12 @@ public:
   void declare_tracer(int problem_type, const Int& rhomidx) override;
 
   void end_tracer_declarations() override;
+
+  void get_buffers_sizes(size_t& buf1, size_t& buf2) override;
+
+  void set_buffers(Real* buf1, Real* buf2) override;
+
+  void finish_setup() override;
 
   int get_problem_type(const Int& tracer_idx) const override;
 
@@ -273,14 +280,20 @@ PROTECTED_CUDA:
   };
 
   struct BulkData {
-    typedef Kokkos::View<Real*, Device> RealList;
     typedef cedr::impl::Unmanaged<RealList> UnmanagedRealList;
 
     UnmanagedRealList l2r_data, r2l_data;
 
-    void init(const MetaData& md, const Int& nslots);
+    BulkData () : inited_(false) {}
+
+    bool inited () const { return inited_; }
+
+    void init(const size_t& l2r_sz, const size_t& r2l_sz);
+    void init(Real* l2r_buf, const size_t& l2r_sz,
+              Real* r2l_buf, const size_t& r2l_sz);
 
   private:
+    bool inited_;
     RealList l2r_data_, r2l_data_;
   };
 
@@ -327,12 +340,14 @@ struct Input {
 Int run_unit_and_randomized_tests(const Parallel::Ptr& p, const Input& in);
 
 Int test_qlt(const Parallel::Ptr& p, const tree::Node::Ptr& tree, const Int& ncells,
-             const Int nrepeat = 1,
+             const Int nrepeat,
              // Diagnostic output for dev and illustration purposes. To be
              // clear, no QLT unit test requires output to be checked; each
              // checks in-memory data and returns a failure count.
-             const bool write = false,
-             const bool verbose = false);
+             const bool write,
+             // Provide memory to QLT for its buffers.
+             const bool external_memory,
+             const bool verbose);
 } // namespace test
 } // namespace qlt
 } // namespace cedr

--- a/cedr/cedr_qlt.hpp
+++ b/cedr/cedr_qlt.hpp
@@ -151,7 +151,8 @@ public:
   // Set up QLT topology and communication data structures based on a tree. Both
   // ncells and tree refer to the global mesh, not just this processor's
   // part. The tree must be identical across ranks.
-  QLT(const Parallel::Ptr& p, const Int& ncells, const tree::Node::Ptr& tree);
+  QLT(const Parallel::Ptr& p, const Int& ncells, const tree::Node::Ptr& tree,
+      CDR::Options options = Options());
 
   void print(std::ostream& os) const override;
 
@@ -347,6 +348,8 @@ Int test_qlt(const Parallel::Ptr& p, const tree::Node::Ptr& tree, const Int& nce
              const bool write,
              // Provide memory to QLT for its buffers.
              const bool external_memory,
+             // Set CDR::Options.prefer_numerical_mass_conservation_to_numerical_bounds.
+             const bool prefer_mass_con_to_bounds,
              const bool verbose);
 } // namespace test
 } // namespace qlt

--- a/cedr/cedr_test_1d_transport.cpp
+++ b/cedr/cedr_test_1d_transport.cpp
@@ -289,6 +289,7 @@ Int run (const mpi::Parallel::Ptr& parallel, const Input& in) {
       cdr->declare_tracer(cedr::ProblemType::conserve |
                           cedr::ProblemType::shapepreserve, 0);
     cdr->end_tracer_declarations();
+    cdr->finish_setup();
     for (Int i = 0; i < in.ncells; ++i)
       cdr->set_rhom(i, 0, p.area(i));
     cdr->print(std::cout);

--- a/cedr/cedr_test_randomized.hpp
+++ b/cedr/cedr_test_randomized.hpp
@@ -14,7 +14,8 @@ namespace test {
 class TestRandomized {
 public:
   TestRandomized(const std::string& cdr_name, const mpi::Parallel::Ptr& p,
-                 const Int& ncells, const bool verbose = false);
+                 const Int& ncells, const bool verbose = false,
+                 const CDR::Options options = CDR::Options());
 
   // The subclass should call this, probably in its constructor.
   void init();
@@ -24,6 +25,7 @@ public:
 
 private:
   const std::string cdr_name_;
+  const CDR::Options options_;
 
 protected:
   struct Tracer {
@@ -141,8 +143,8 @@ private:
   static void generate_Q(const Tracer& t, Values& v);
   static void permute_Q(const Tracer& t, Values& v);
   static std::string get_tracer_name(const Tracer& t);
-  static Int check(const std::string& cdr_name, const mpi::Parallel& p,
-                   const std::vector<Tracer>& ts, const Values& v);
+  Int check(const std::string& cdr_name, const mpi::Parallel& p,
+            const std::vector<Tracer>& ts, const Values& v);
 };
 
 } // namespace test


### PR DESCRIPTION
Let the user provide memory for the large buffers in the CDR algorithms. For example, this lets HOMME provide `edge_g%buf` and `edge_g%receive`, sharing memory among the dycore, CEDR, SLMM, and dp_coupling.

Also make an interface for tuning some numerics.

Uses must now call `cdr->finish_setup()` after `cdr->end_tracer_declaration()`. Between these two calls, one can query the buffer sizes and provide the buffers. If this is not done, then the CDR allocates the buffers as was done previously.