### PR TITLE
Changed from View::traits::memory_traits::TraitName to View::traits::memory_traits::is_trait_name

### DIFF
--- a/cedr/cedr_kokkos.hpp
+++ b/cedr/cedr_kokkos.hpp
@@ -28,11 +28,11 @@ namespace impl {
 template <typename View>
 struct MemoryTraitsMask {
   enum : unsigned int {
-    value = ((View::traits::memory_traits::RandomAccess ? Kokkos::RandomAccess : 0) |
-             (View::traits::memory_traits::Atomic ? Kokkos::Atomic : 0) |
-             (View::traits::memory_traits::Restrict ? Kokkos::Restrict : 0) |
-             (View::traits::memory_traits::Aligned ? Kokkos::Aligned : 0) |
-             (View::traits::memory_traits::Unmanaged ? Kokkos::Unmanaged : 0))
+    value = ((View::traits::memory_traits::is_random_access ? Kokkos::RandomAccess : 0) |
+             (View::traits::memory_traits::is_atomic ? Kokkos::Atomic : 0) |
+             (View::traits::memory_traits::is_restrict ? Kokkos::Restrict : 0) |
+             (View::traits::memory_traits::is_aligned ? Kokkos::Aligned : 0) |
+             (View::traits::memory_traits::is_unmanaged ? Kokkos::Unmanaged : 0))
       };
 };
 


### PR DESCRIPTION
After most recent update to Trilinos (with deprecated code turned off), cedr_kokkos.hpp could no longer be compiled.