### PR TITLE
Factor out DeviceOp from CDR.

### DIFF
--- a/cedr/cedr_bfb_tree_allreduce.cpp
+++ b/cedr/cedr_bfb_tree_allreduce.cpp
@@ -55,10 +55,13 @@ template <typename ES>
 const Real* BfbTreeAllReducer<ES>
 ::get_send_host (const ConstRealList& send) const {
   cedr_assert(send.extent_int(0) == nlocal_*nfield_);
-  if ( ! impl::OnGpu<ES>::value) return send.data();
-  RealListHost m(bd_.data() + ns_->nslots * nfield_, nlocal_*nfield_);
-  Kokkos::deep_copy(m, send);
-  return m.data();
+  if (impl::OnGpu<ES>::value) {
+    RealListHost m(bd_.data() + ns_->nslots * nfield_, nlocal_*nfield_);
+    Kokkos::deep_copy(m, send);
+    return m.data();
+  } else {
+    return send.data();
+  }
 }
 
 template <typename ES>

--- a/cedr/cedr_caas.cpp
+++ b/cedr/cedr_caas.cpp
@@ -36,10 +36,13 @@ namespace caas {
 
 template <typename ES>
 CAAS<ES>::CAAS (const mpi::Parallel::Ptr& p, const Int nlclcells,
-                const typename UserAllReducer::Ptr& uar)
-  : p_(p), user_reducer_(uar), nlclcells_(nlclcells), nrhomidxs_(0),
-    need_conserve_(false), finished_setup_(false)
-{
+                const typename UserAllReducer::Ptr& uar) {
+  p_ = p;
+  user_reducer_ = uar;
+  o.nlclcells_ = nlclcells;
+  o.nrhomidxs_ = 0;
+  o.need_conserve_ = false;
+  finished_setup_ = false;
   cedr_throw_if(nlclcells == 0, "CAAS does not support 0 cells on a rank.");
   tracer_decls_ = std::make_shared<std::vector<Decl> >();  
 }
@@ -51,32 +54,32 @@ void CAAS<ES>::declare_tracer(int problem_type, const Int& rhomidx) {
   cedr_throw_if(rhomidx > 0, "rhomidx > 0 is not supported yet.");
   tracer_decls_->push_back(Decl(problem_type, rhomidx));
   if (problem_type & ProblemType::conserve)
-    need_conserve_ = true;
-  nrhomidxs_ = std::max(nrhomidxs_, rhomidx+1);
+    o.need_conserve_ = true;
+  o.nrhomidxs_ = std::max(o.nrhomidxs_, rhomidx+1);
 }
 
 template <typename ES>
 void CAAS<ES>::end_tracer_declarations () {
   cedr_throw_if(tracer_decls_->size() == 0, "#tracers is 0.");
-  cedr_throw_if(nrhomidxs_ == 0, "#rhomidxs is 0.");
-  probs_ = IntList("CAAS probs", static_cast<Int>(tracer_decls_->size()));
-  probs_h_ = Kokkos::create_mirror_view(probs_);
+  cedr_throw_if(o.nrhomidxs_ == 0, "#rhomidxs is 0.");
+  o.probs_ = IntList("CAAS probs", static_cast<Int>(tracer_decls_->size()));
+  probs_h_ = Kokkos::create_mirror_view(o.probs_);
   //t2r_ = IntList("CAAS t2r", static_cast<Int>(tracer_decls_->size()));
-  for (Int i = 0; i < probs_.extent_int(0); ++i) {
+  for (Int i = 0; i < o.probs_.extent_int(0); ++i) {
     probs_h_(i) = (*tracer_decls_)[i].probtype;
     //t2r_(i) = (*tracer_decls_)[i].rhomidx;
   }
-  Kokkos::deep_copy(probs_, probs_h_);
+  Kokkos::deep_copy(o.probs_, probs_h_);
   tracer_decls_ = nullptr;
 }
 
 template <typename ES>
 void CAAS<ES>::get_buffers_sizes (size_t& buf1, size_t& buf2, size_t& buf3) {
-  const Int e = need_conserve_ ? 1 : 0;
-  const auto nslots = 4*probs_.size();
-  buf1 = nlclcells_ * ((3+e)*probs_.size() + 1);
-  cedr_assert( ! user_reducer_ || nlclcells_ % user_reducer_->n_accum_in_place() == 0);
-  buf2 = nslots*(user_reducer_ ? (nlclcells_ / user_reducer_->n_accum_in_place()) : 1);
+  const Int e = o.need_conserve_ ? 1 : 0;
+  const auto nslots = 4*o.probs_.size();
+  buf1 = o.nlclcells_ * ((3+e)*o.probs_.size() + 1);
+  cedr_assert( ! user_reducer_ || o.nlclcells_ % user_reducer_->n_accum_in_place() == 0);
+  buf2 = nslots*(user_reducer_ ? (o.nlclcells_ / user_reducer_->n_accum_in_place()) : 1);
   buf3 = nslots;
 }
 
@@ -91,7 +94,7 @@ template <typename ES>
 void CAAS<ES>::set_buffers (Real* buf1, Real* buf2) {
   size_t buf1sz, buf2sz, buf3sz;
   get_buffers_sizes(buf1sz, buf2sz, buf3sz);
-  d_ = RealList(buf1, buf1sz);
+  o.d_ = RealList(buf1, buf1sz);
   send_ = RealList(buf2, buf2sz);
   recv_ = RealList(buf2 + buf2sz, buf3sz);
 }
@@ -105,7 +108,7 @@ void CAAS<ES>::finish_setup () {
   size_t buf1, buf2, buf3;
   get_buffers_sizes(buf1, buf2, buf3);
   // (rho, Qm, Qm_min, Qm_max, [Qm_prev])
-  d_ = RealList("CAAS data", buf1);
+  o.d_ = RealList("CAAS data", buf1);
   // (e'Qm_clip, e'Qm, e'Qm_min, e'Qm_max, [e'Qm_prev])
   send_ = RealList("CAAS send", buf2);
   recv_ = RealList("CAAS recv", buf3);
@@ -114,38 +117,23 @@ void CAAS<ES>::finish_setup () {
 
 template <typename ES>
 int CAAS<ES>::get_problem_type (const Int& tracer_idx) const {
-  cedr_assert(tracer_idx >= 0 && tracer_idx < probs_.extent_int(0));
+  cedr_assert(tracer_idx >= 0 && tracer_idx < o.probs_.extent_int(0));
   return probs_h_[tracer_idx];
 }
 
 template <typename ES>
 Int CAAS<ES>::get_num_tracers () const {
-  return probs_.extent_int(0);
-}
-
-template <typename RealList, typename IntList>
-KOKKOS_INLINE_FUNCTION static void
-calc_Qm_scalars (const RealList& d, const IntList& probs,
-                 const Int& nt, const Int& nlclcells,
-                 const Int& k, const Int& os, const Int& i,
-                 Real& Qm_clip, Real& Qm_term) {
-  const Real Qm = d(os+i);
-  Qm_term = (probs(k) & ProblemType::conserve ?
-             d(os + nlclcells*3*nt + i) /* Qm_prev */ :
-             Qm);
-  const Real Qm_min = d(os + nlclcells*  nt + i);
-  const Real Qm_max = d(os + nlclcells*2*nt + i);
-  Qm_clip = cedr::impl::min(Qm_max, cedr::impl::max(Qm_min, Qm));
+  return o.probs_.extent_int(0);
 }
 
 template <typename ES>
 void CAAS<ES>::reduce_locally () {
   const bool user_reduces = user_reducer_ != nullptr;
-  ConstExceptGnu Int nt = probs_.size(), nlclcells = nlclcells_;
+  ConstExceptGnu Int nt = o.probs_.size(), nlclcells = o.nlclcells_;
 
-  const auto probs = probs_;
+  const auto probs = o.probs_;
   const auto send = send_;
-  const auto d = d_;
+  const auto d = o.d_;
   if (user_reduces) {
     const Int n_accum_in_place = user_reducer_->n_accum_in_place();
     const Int nlclaccum = nlclcells / n_accum_in_place;
@@ -223,9 +211,9 @@ void CAAS<ES>::reduce_globally () {
 template <typename ES>
 void CAAS<ES>::finish_locally () {
   using ESU = cedr::impl::ExeSpaceUtils<ES>;
-  ConstExceptGnu Int nt = probs_.size(), nlclcells = nlclcells_;
+  ConstExceptGnu Int nt = o.probs_.size(), nlclcells = o.nlclcells_;
   const auto recv = recv_;
-  const auto d = d_;
+  const auto d = o.d_;
   const auto adjust_Qm = KOKKOS_LAMBDA (const typename ESU::Member& t) {
     const auto k = t.league_rank();
     const auto os = (k+1)*nlclcells;
@@ -265,13 +253,16 @@ void CAAS<ES>::finish_locally () {
 }
 
 template <typename ES>
+const CAAS<ES>::DeviceOp& CAAS<ES>::get_device_op() { return o; }
+
+template <typename ES>
 void CAAS<ES>::run () {
   cedr_assert(finished_setup_);
   reduce_locally();
   const bool user_reduces = user_reducer_ != nullptr;
   if (user_reduces)
     (*user_reducer_)(*p_, send_.data(), recv_.data(),
-                     nlclcells_ / user_reducer_->n_accum_in_place(),
+                     o.nlclcells_ / user_reducer_->n_accum_in_place(),
                      recv_.size(), MPI_SUM);
   else
     reduce_globally();

--- a/cedr/cedr_caas.hpp
+++ b/cedr/cedr_caas.hpp
@@ -6,6 +6,8 @@
 
 #include "cedr_cdr.hpp"
 
+#include <vector>
+
 namespace cedr {
 // ClipAndAssuredSum.
 namespace caas {
@@ -17,6 +19,7 @@ public:
   typedef CAAS<ExeSpace> Me;
   typedef std::shared_ptr<Me> Ptr;
   typedef Kokkos::View<Real*, Kokkos::LayoutLeft, Device> RealList;
+  typedef Kokkos::View<Int*, Kokkos::LayoutLeft, Device> IntList;
 
 public:
 
@@ -62,23 +65,31 @@ public:
 
   Int get_num_tracers() const override;
 
-  // lclcellidx is trivial; it is the user's index for the cell.
-  KOKKOS_INLINE_FUNCTION
-  void set_rhom(const Int& lclcellidx, const Int& rhomidx, const Real& rhom) const override;
+  struct DeviceOp : public CDR::DeviceOp {
+    // lclcellidx is trivial; it is the user's index for the cell.
+    KOKKOS_INLINE_FUNCTION
+    void set_rhom(const Int& lclcellidx, const Int& rhomidx, const Real& rhom) const override;
 
-  KOKKOS_INLINE_FUNCTION
-  void set_Qm(const Int& lclcellidx, const Int& tracer_idx,
-              const Real& Qm, const Real& Qm_min, const Real& Qm_max,
-              const Real Qm_prev = std::numeric_limits<Real>::infinity()) const override;
+    KOKKOS_INLINE_FUNCTION
+    void set_Qm(const Int& lclcellidx, const Int& tracer_idx,
+                const Real& Qm, const Real& Qm_min, const Real& Qm_max,
+                const Real Qm_prev = std::numeric_limits<Real>::infinity()) const override;
+
+    KOKKOS_INLINE_FUNCTION
+    Real get_Qm(const Int& lclcellidx, const Int& tracer_idx) const override;
+
+    Int nlclcells_, nrhomidxs_;
+    bool need_conserve_;
+    IntList probs_;
+    RealList d_;
+  };
+
+  const DeviceOp& get_device_op() override;
 
   void run() override;
 
-  KOKKOS_INLINE_FUNCTION
-  Real get_Qm(const Int& lclcellidx, const Int& tracer_idx) const override;
-
 protected:
   typedef cedr::impl::Unmanaged<RealList> UnmanagedRealList;
-  typedef Kokkos::View<Int*, Kokkos::LayoutLeft, Device> IntList;
 
   struct Decl {
     int probtype;
@@ -89,14 +100,12 @@ protected:
 
   mpi::Parallel::Ptr p_;
   typename UserAllReducer::Ptr user_reducer_;
-
-  Int nlclcells_, nrhomidxs_;
   std::shared_ptr<std::vector<Decl> > tracer_decls_;
-  bool need_conserve_;
-  IntList probs_, t2r_;
   typename IntList::HostMirror probs_h_;
-  RealList d_, send_, recv_;
+  IntList t2r_;
+  RealList send_, recv_;
   bool finished_setup_;
+  DeviceOp o;
 
   void reduce_globally();
 

--- a/cedr/cedr_caas_inl.hpp
+++ b/cedr/cedr_caas_inl.hpp
@@ -11,15 +11,15 @@ namespace cedr {
 namespace caas {
 
 template <typename ES> KOKKOS_INLINE_FUNCTION
-void CAAS<ES>::set_rhom (const Int& lclcellidx, const Int& rhomidx,
-                         const Real& rhom) const {
+void CAAS<ES>::DeviceOp
+::set_rhom (const Int& lclcellidx, const Int& rhomidx, const Real& rhom) const {
   cedr_kernel_assert(lclcellidx >= 0 && lclcellidx < nlclcells_);
   cedr_kernel_assert(rhomidx >= 0 && rhomidx < nrhomidxs_);
   d_(lclcellidx) = rhom;
 }
 
 template <typename ES> KOKKOS_INLINE_FUNCTION
-void CAAS<ES>
+void CAAS<ES>::DeviceOp
 ::set_Qm (const Int& lclcellidx, const Int& tracer_idx,
           const Real& Qm, const Real& Qm_min, const Real& Qm_max,
           const Real Qm_prev) const {
@@ -34,10 +34,26 @@ void CAAS<ES>
 }
 
 template <typename ES> KOKKOS_INLINE_FUNCTION
-Real CAAS<ES>::get_Qm (const Int& lclcellidx, const Int& tracer_idx) const {
+Real CAAS<ES>::DeviceOp::
+get_Qm (const Int& lclcellidx, const Int& tracer_idx) const {
   cedr_kernel_assert(lclcellidx >= 0 && lclcellidx < nlclcells_);
   cedr_kernel_assert(tracer_idx >= 0 && tracer_idx < probs_.extent_int(0));
   return d_((1 + tracer_idx)*nlclcells_ + lclcellidx);
+}
+
+template <typename RealList, typename IntList>
+KOKKOS_INLINE_FUNCTION static void
+calc_Qm_scalars (const RealList& d, const IntList& probs,
+                 const Int& nt, const Int& nlclcells,
+                 const Int& k, const Int& os, const Int& i,
+                 Real& Qm_clip, Real& Qm_term) {
+  const Real Qm = d(os+i);
+  Qm_term = (probs(k) & ProblemType::conserve ?
+             d(os + nlclcells*3*nt + i) /* Qm_prev */ :
+             Qm);
+  const Real Qm_min = d(os + nlclcells*  nt + i);
+  const Real Qm_max = d(os + nlclcells*2*nt + i);
+  Qm_clip = cedr::impl::min(Qm_max, cedr::impl::max(Qm_min, Qm));
 }
 
 } // namespace caas

--- a/cedr/cedr_qlt_inl.hpp
+++ b/cedr/cedr_qlt_inl.hpp
@@ -12,17 +12,18 @@ namespace cedr {
 namespace qlt {
 
 template <typename ES> KOKKOS_INLINE_FUNCTION
-void QLT<ES>::set_rhom (const Int& lclcellidx, const Int& rhomidx,
-                        const Real& rhom) const {
+void QLT<ES>::DeviceOp::
+set_rhom (const Int& lclcellidx, const Int& rhomidx, const Real& rhom) const {
   const Int ndps = md_.a_d.prob2bl2r[md_.nprobtypes];
   bd_.l2r_data(ndps*lclcellidx) = rhom;  
 }
 
 template <typename ES> KOKKOS_INLINE_FUNCTION
-void QLT<ES>::set_Qm (const Int& lclcellidx, const Int& tracer_idx,
-                      const Real& Qm,
-                      const Real& Qm_min, const Real& Qm_max,
-                      const Real Qm_prev) const {
+void QLT<ES>::DeviceOp::
+set_Qm (const Int& lclcellidx, const Int& tracer_idx,
+        const Real& Qm,
+        const Real& Qm_min, const Real& Qm_max,
+        const Real Qm_prev) const {
   const Int ndps = md_.a_d.prob2bl2r[md_.nprobtypes];
   Real* bd; {
     const Int bdi = md_.a_d.trcr2bl2r(tracer_idx);
@@ -57,7 +58,8 @@ void QLT<ES>::set_Qm (const Int& lclcellidx, const Int& tracer_idx,
 }
 
 template <typename ES> KOKKOS_INLINE_FUNCTION
-Real QLT<ES>::get_Qm (const Int& lclcellidx, const Int& tracer_idx) const {
+Real QLT<ES>::DeviceOp::
+get_Qm (const Int& lclcellidx, const Int& tracer_idx) const {
   const Int ndps = md_.a_d.prob2br2l[md_.nprobtypes];
   const Int bdi = md_.a_d.trcr2br2l(tracer_idx);
   return bd_.r2l_data(ndps*lclcellidx + bdi);

--- a/cedr/cedr_test_1d_transport.cpp
+++ b/cedr/cedr_test_1d_transport.cpp
@@ -170,6 +170,7 @@ class Problem1D {
   static void run_cdr (const Problem1D& p, CDR& cdr,
                        const Real* yp, Real* y, const Int* dods) {
     const Int n = p.ncells();
+    const auto& op = cdr.get_device_op();
     for (Int i = 0; i < n; ++i) {
       const Int* dod = dods + 4*i;
       Real min = yp[dod[0]], max = min;
@@ -179,11 +180,11 @@ class Problem1D {
         max = std::max(max, v);
       }
       const Real area_i = p.area(i);
-      cdr.set_Qm(i, 0, y[i]*area_i, min*area_i, max*area_i, yp[i]*area_i);
+      op.set_Qm(i, 0, y[i]*area_i, min*area_i, max*area_i, yp[i]*area_i);
     }
     cdr.run();
     for (Int i = 0; i < n; ++i)
-      y[i] = cdr.get_Qm(i, 0) / p.area(i);
+      y[i] = op.get_Qm(i, 0) / p.area(i);
     y[n] = y[0];
   }
 
@@ -290,8 +291,9 @@ Int run (const mpi::Parallel::Ptr& parallel, const Input& in) {
                           cedr::ProblemType::shapepreserve, 0);
     cdr->end_tracer_declarations();
     cdr->finish_setup();
+    const auto& op = cdr->get_device_op();
     for (Int i = 0; i < in.ncells; ++i)
-      cdr->set_rhom(i, 0, p.area(i));
+      op.set_rhom(i, 0, p.area(i));
     cdr->print(std::cout);
   }
 

--- a/cedr/cedr_test_mpi_device_ptr.cpp
+++ b/cedr/cedr_test_mpi_device_ptr.cpp
@@ -5,21 +5,30 @@
 
 // Seg fault if MPI can't handle device pointers. Thus, we'll isolate
 // this environment-related problem from true bugs inside COMPOSE.
+template <typename ES>
 void test_mpi_device_ptr () {
   using namespace cedr;
   static const int n = 42, tag = 24;
-  Kokkos::View<int*> s("s", n), r("r", n);
+  Kokkos::View<int*, ES> r("r", n);
   const auto p = mpi::make_parallel(MPI_COMM_WORLD);
   mpi::Request req;
   mpi::irecv(*p, r.data(), n, p->root(), tag, &req);
-  mpi::isend(*p, s.data(), n, p->root(), tag);
+  if (p->amroot()) {
+    Kokkos::View<int*, ES> s("s", n);
+    const auto sh = Kokkos::create_mirror_view(s);
+    for (int i = 0; i < n; ++i) sh(i) = i;
+    Kokkos::deep_copy(s, sh);
+    for (int i = 0; i < p->size(); ++i)
+      mpi::isend(*p, s.data(), n, i, tag);
+  }
   mpi::waitall(1, &req);
 }
 
 int main (int argc, char** argv) {
   MPI_Init(&argc, &argv);
   Kokkos::initialize(argc, argv); {
-    test_mpi_device_ptr();
+    test_mpi_device_ptr<Kokkos::DefaultHostExecutionSpace>();
+    test_mpi_device_ptr<Kokkos::DefaultExecutionSpace>();
   } Kokkos::finalize();
   MPI_Finalize();
   // If we didn't seg fault, we passed.

--- a/cedr/cedr_test_randomized.hpp
+++ b/cedr/cedr_test_randomized.hpp
@@ -8,6 +8,8 @@
 #include "cedr_mpi.hpp"
 #include "cedr_util.hpp"
 
+#include <vector>
+
 namespace cedr {
 namespace test {
 

--- a/cedr/cedr_test_randomized_inl.hpp
+++ b/cedr/cedr_test_randomized_inl.hpp
@@ -24,7 +24,8 @@ Int TestRandomized::run (const Int nrepeat, const bool write) {
     for (const auto& t : tracers_)
       write_pre(t, v);
 
-  CDRT cdr = static_cast<CDRT&>(get_cdr());
+  const typename CDRT::DeviceOp cdr
+    = static_cast<const typename CDRT::DeviceOp&>(get_cdr().get_device_op());
   ValuesDevice<ES> vd(v);
   vd.sync_device();
 

--- a/cedr/cedr_tree.hpp
+++ b/cedr/cedr_tree.hpp
@@ -7,6 +7,8 @@
 #include "cedr_tree_caller.hpp"
 #include "cedr_util.hpp"
 
+#include <vector>
+
 namespace cedr {
 namespace tree {
 using cedr::mpi::Parallel;


### PR DESCRIPTION
The practical motivation for this refactor is to avoid shared_ptr
host-device warnings in Cuda builds. These were innocuous, but we
want a build free of warnings.

The set/get_Qm and set_rhom device functions now are called from
an object returned by cdr.get_device_op().